### PR TITLE
Specify python 3.9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 LABEL maintainer="Michael Riffle <mriffle@uw.edu>"
 
 ADD entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Updated Dockerfile to specify Python 3.9, which looks to be required currently for CONGA